### PR TITLE
Current State Node: Preserve original message with option to override payload

### DIFF
--- a/nodes/api_current-state/api_current-state.html
+++ b/nodes/api_current-state/api_current-state.html
@@ -11,6 +11,7 @@
             name:             { value: '' },
             server:           { value: '', type: 'server', required: true },
             halt_if:          { value: '' },
+            override_payload: { value: true },			
             entity_id:        { value: '', required: true },
             propertyType:     { value: 'msg', required: true },
             property:         { value: 'payload', required: true }
@@ -101,6 +102,12 @@
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
         <input type="hidden" id="node-input-propertyType">
         <input type="text" id="node-input-property" style="width:70%;" />
+    </div>
+    
+    <div class="form-row">
+        <label for="node-input-override_payload">&nbsp;</label>
+        <input type="checkbox" id="node-input-override_payload" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
+        <span>Override Payload</span>
     </div>
     
     <div class="form-row">

--- a/nodes/api_current-state/api_current-state.js
+++ b/nodes/api_current-state/api_current-state.js
@@ -7,6 +7,7 @@ module.exports = function(RED) {
         config: {
             name: {},
             halt_if: {},
+            override_payload: {},
             entity_id: {},
             propertyType: {},
             property: {},
@@ -52,17 +53,24 @@ module.exports = function(RED) {
                 return null;
             }
 
+            // default switch to true if undefined (backward compatibility
+            const override_payload = this.nodeConfig.override_payload !== false;
+
             // Output the currentState Object to the destination specified
             if (this.nodeConfig.propertyType == 'flow') {
                 this.context().flow.set(this.nodeConfig.property, currentState);
             } else if (this.nodeConfig.propertyType == 'global') {
                 this.context().global.set(this.nodeConfig.property, currentState);
             } else {
-                RED.util.setMessageProperty(message, this.nodeConfig.property, currentState);
+				if (override_payload) {
+					RED.util.setMessageProperty(message, this.nodeConfig.property, currentState);					
+					this.node.send(message);
+				} else {
+					this.node.send(message);
+				}
             }
 	    var prettyDate = new Date().toLocaleDateString("en-US",{month: 'short', day: 'numeric', hour12: false, hour: 'numeric', minute: 'numeric'});
-	    this.status({fill:"green",shape:"dot",text:`${currentState.state} at: ${prettyDate}`});
-            this.node.send(message);
+	    this.status({fill:"green",shape:"dot",text:`${currentState.state} at: ${prettyDate}`});    
         }
     }
 


### PR DESCRIPTION
This is a clone of PR 55 of the orignial node-red-contrib-home-assistant from declankenny.

This change adds a checkbox to the UI, override_payload to the Current State Node, allowing the user to preserve the incoming message payload or override them with the entity.id and status - replicating the existing behavior.

Control defaults to selected in the UI form to replicate existing design.

On the back-end, the code will trap for undefined values coming from this and default to selected. This ensures backward compatibility for existing nodes.