### PR TITLE
Poll state Refactor

### DIFF
--- a/nodes/poll-state/poll-state.js
+++ b/nodes/poll-state/poll-state.js
@@ -50,7 +50,7 @@ module.exports = function(RED) {
                 const state = await this.getState(this.nodeConfig.entity_id);
                 if (!state) {
                     this.warn(`could not find state with entity_id "${this.nodeConfig.entity_id}"`);
-                    this.status(fill:"red",shape:"ring",text:`no state found for "${this.nodeConfig.entity_id}"`);
+                    this.status({fill:"red",shape:"ring",text:`no state found for ${this.nodeConfig.entity_id}`});
                     return;
                 }
 
@@ -62,6 +62,8 @@ module.exports = function(RED) {
                         topic:   this.nodeConfig.entity_id,
                         payload: { timeSinceChanged, timeSinceChangedMs, dateChanged, data: state }
                     });
+	    	    var prettyDate = new Date().toLocaleDateString("en-US",{month: 'short', day: 'numeric', hour12: false, hour: 'numeric', minute: 'numeric'});
+		    this.status({fill:"green",shape:"dot",text:`${state} at: ${prettyDate}`});
                 } else {
                     this.warn(`could not calculate time since changed for entity_id "${this.nodeConfig.entity_id}"`);
                 }
@@ -80,7 +82,7 @@ module.exports = function(RED) {
             }
             return state;
 	    var prettyDate = new Date().toLocaleDateString("en-US",{month: 'short', day: 'numeric', hour12: false, hour: 'numeric', minute: 'numeric'});
-            this.status(fill:"green",shape:"dot",text:`${state} at: ${prettyDate}`);
+            this.status({fill:"green",shape:"dot",text:`${state} at: ${prettyDate}`});
         }
     }
     RED.nodes.registerType('poll-state', TimeSinceStateNode);

--- a/nodes/server-events-state-changed/server-events-state-changed.js
+++ b/nodes/server-events-state-changed/server-events-state-changed.js
@@ -33,7 +33,7 @@ module.exports = function(RED) {
                     if (shouldHaltIfState) {
                         this.debug('flow halted due to "halt if state" setting');
 	                var prettyDate = new Date().toLocaleDateString("en-US",{month: 'short', day: 'numeric', hour12: false, hour: 'numeric', minute: 'numeric'});
-		        this.status({fill:"yellow",shape:"ring",text:`${event.new_state.state} at: ${prettyDate}`}); 
+		        this.status({fill:"red",shape:"ring",text:`${event.new_state.state} at: ${prettyDate}`}); 
                         return null;
                     }
 


### PR DESCRIPTION
I mainly did this to keep myself sane by making the poll-state node match the same format as the current-state node. Feel free to reject this if you don't want to go this route.

Currently, poll-state node msg.payload is an object and not just the state of the node like current-state. I moved msg.payload to msg.data like current-state and made msg.payload the actually state.

Also fixed the status of the node to reflect the state and not the object that was msg.payload.

This is a breaking change like the current-state refactor, #20, was.