### PR TITLE
Fix for call-service node replacing msg object

### DIFF
--- a/nodes/api_call-service/api_call-service.js
+++ b/nodes/api_call-service/api_call-service.js
@@ -51,13 +51,13 @@ module.exports = function(RED) {
             this.debug(`Calling Service: ${apiDomain}:${apiService} -- ${JSON.stringify(apiData || {})}`);
             var prettyDate = new Date().toLocaleDateString("en-US",{month: 'short', day: 'numeric', hour12: false, hour: 'numeric', minute: 'numeric'});
             this.status({fill:"green",shape:"dot",text:`${apiDomain}.${apiService} called at: ${prettyDate}`});
-            this.send({
-                payload: {
-                    domain:  apiDomain,
-                    service: apiService,
-                    data:    apiData || null
-                }
-            });
+
+            message.payload =  {
+                domain:  apiDomain,
+                service: apiService,
+                data:    apiData || null
+            };
+            this.send(message);
 
             return this.nodeConfig.server.api.callService(apiDomain, apiService, apiData)
                 .catch(err => {


### PR DESCRIPTION
Fixes the issue where the call-service node was replacing the message object. Which caused loss of any msg data passed into the node.

https://github.com/AYapejian/node-red-contrib-home-assistant/issues/97